### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Pod/To/Markdown.pm6
+++ b/lib/Pod/To/Markdown.pm6
@@ -27,7 +27,7 @@ say pod2markdown($=pod);
 
 =DESCRIPTION
 
-class Pod::To::Markdown;
+unit class Pod::To::Markdown;
 
 #| Render Pod as Markdown
 sub pod2markdown($pod, Str :$positional-separator? = "\n\n") is export {


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
