### PR TITLE
Fix up expectations in definition.t

### DIFF
--- a/t/definition.t
+++ b/t/definition.t
@@ -15,7 +15,7 @@ asdf1
 ```
 sub asdf(
     Str $asdf1, 
-    Str :asdf2($asdf2) = { ... }
+    Str :$asdf2 = { ... }
 ) returns Str
 ```
 
@@ -34,7 +34,7 @@ t
 
 ```
 method asdf(
-    Str :asdf($asdf) = { ... }
+    Str :$asdf = { ... }
 ) returns Str
 ```
 


### PR DESCRIPTION
I don't think we should expect the redundant naming of `:asdf2($asdf2)`,
and I'm guessing the reason the test checks for this is just because
that's how `Parameter.perl` used to work.
